### PR TITLE
Implement Windows path support in SambaHook

### DIFF
--- a/providers/samba/docs/connections.rst
+++ b/providers/samba/docs/connections.rst
@@ -42,3 +42,6 @@ Login
 
 Password
     The password of the user that will be used for authentication against the Samba server.
+
+Share Type
+    The share OS type (``posix`` or ``windows``). Used to determine the formatting of file and folder paths.

--- a/providers/samba/src/airflow/providers/samba/hooks/samba.py
+++ b/providers/samba/src/airflow/providers/samba/hooks/samba.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import posixpath
+import ntpath
 from functools import wraps
 from shutil import copyfileobj
 from typing import TYPE_CHECKING, Any
@@ -85,6 +86,8 @@ class SambaHook(BaseHook):
         self._connection_cache.clear()
 
     def _join_path(self, path):
+        if smbclient._os.is_remote_path(path):
+            return ntpath.join(f"\\\\{self._host}", self._share, path.lstrip("\\"))
         return f"//{posixpath.join(self._host, self._share, path.lstrip('/'))}"
 
     @wraps(smbclient.link)

--- a/providers/samba/src/airflow/providers/samba/hooks/samba.py
+++ b/providers/samba/src/airflow/providers/samba/hooks/samba.py
@@ -52,7 +52,7 @@ class SambaHook(BaseHook):
         self,
         samba_conn_id: str = default_conn_name,
         share: str | None = None,
-        share_type: Literal["posix", "windows"] = None,
+        share_type: Literal["posix", "windows"] | None = None,
     ) -> None:
         super().__init__()
         conn = self.get_connection(samba_conn_id)

--- a/providers/samba/src/airflow/providers/samba/hooks/samba.py
+++ b/providers/samba/src/airflow/providers/samba/hooks/samba.py
@@ -315,6 +315,7 @@ class SambaHook(BaseHook):
     def get_ui_field_behaviour(cls) -> dict[str, Any]:
         """Return custom field behaviour."""
         return {
+            "hidden_fields": [],
             "relabeling": {"schema": "Share"},
         }
 

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -148,18 +148,18 @@ class TestSambaHook:
             assert dict(kwargs, **connection_settings) == p_kwargs
 
     @pytest.mark.parametrize(
-        "path, path_type, full_path",
+        "path, share_type, full_path",
         [
-            # Linux path -> Linux path, no path_type (default)
+            # Linux path -> Linux path, no share_type (default)
             ("/start/path/with/slash", None, "//ip/share/start/path/with/slash"),
             ("start/path/without/slash", None, "//ip/share/start/path/without/slash"),
-            # Linux path -> Linux path, explicit path_type (posix)
+            # Linux path -> Linux path, explicit share_type (posix)
             ("/start/path/with/slash/posix", "posix", "//ip/share/start/path/with/slash/posix"),
             ("start/path/without/slash/posix", "posix", "//ip/share/start/path/without/slash/posix"),
-            # Linux path -> Windows path, explicit path_type (windows)
+            # Linux path -> Windows path, explicit share_type (windows)
             ("/start/path/with/slash/windows", "windows", r"\\ip\share\start\path\with\slash\windows"),
             ("start/path/without/slash/windows", "windows", r"\\ip\share\start\path\without\slash\windows"),
-            # Windows path -> Windows path, explicit path_type (windows)
+            # Windows path -> Windows path, explicit share_type (windows)
             (
                 r"\start\path\with\backslash\windows",
                 "windows",
@@ -177,7 +177,7 @@ class TestSambaHook:
         self,
         get_conn_mock,
         path,
-        path_type,
+        share_type,
         full_path,
     ):
         CONNECTION = Connection(
@@ -188,7 +188,7 @@ class TestSambaHook:
         )
 
         get_conn_mock.return_value = CONNECTION
-        hook = SambaHook("samba_default", path_type=path_type)
+        hook = SambaHook("samba_default", share_type=share_type)
         assert hook._join_path(path) == full_path
 
     @mock.patch("airflow.providers.samba.hooks.samba.smbclient.open_file", return_value=mock.Mock())

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -152,6 +152,8 @@ class TestSambaHook:
         [
             ("/start/path/with/slash", "//ip/share/start/path/with/slash"),
             ("start/path/without/slash", "//ip/share/start/path/without/slash"),
+            ("/start/path/with/windowslash","\\windowsSharer\windowsShare\windowsDirectory"),
+            ("start/path/without/windowslash","\\windowsSharer\windowsShare\windowsDirectory"),
         ],
     )
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -148,16 +148,24 @@ class TestSambaHook:
             assert dict(kwargs, **connection_settings) == p_kwargs
 
     @pytest.mark.parametrize(
-        "path, full_path",
+        "path, path_type, full_path",
         [
-            ("/start/path/with/slash", "//ip/share/start/path/with/slash"),
-            ("start/path/without/slash", "//ip/share/start/path/without/slash"),
-            ("/start/path/with/windowslash","\\windowsSharer\windowsShare\windowsDirectory"),
-            ("start/path/without/windowslash","\\windowsSharer\windowsShare\windowsDirectory"),
+            # Linux path -> Linux path, no path_type (default)
+            ("/start/path/with/slash", None, "//ip/share/start/path/with/slash"),
+            ("start/path/without/slash", None, "//ip/share/start/path/without/slash"),
+            # Linux path -> Linux path, explicit path_type (posix)
+            ("/start/path/with/slash/posix", "posix", "//ip/share/start/path/with/slash/posix"),
+            ("start/path/without/slash/posix", "posix", "//ip/share/start/path/without/slash/posix"),
+            # Linux path -> Windows path, explicit path_type (windows)
+            ("/start/path/with/slash/windows", "windows", r"\\ip\share\start\path\with\slash\windows"),
+            ("start/path/without/slash/windows", "windows", r"\\ip\share\start\path\without\slash\windows"),
+            # Windows path -> Windows path, explicit path_type (windows)
+            (r"\start\path\with\backslash\windows", "windows", r"\\ip\share\start\path\with\backslash\windows"),
+            (r"start\path\without\backslash\windows", "windows", r"\\ip\share\start\path\without\backslash\windows"),
         ],
     )
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
-    def test__join_path(self, get_conn_mock, path, full_path):
+    def test__join_path(self, get_conn_mock, path, path_type, full_path,):
         CONNECTION = Connection(
             host="ip",
             schema="share",
@@ -166,7 +174,7 @@ class TestSambaHook:
         )
 
         get_conn_mock.return_value = CONNECTION
-        hook = SambaHook("samba_default")
+        hook = SambaHook("samba_default", path_type=path_type)
         assert hook._join_path(path) == full_path
 
     @mock.patch("airflow.providers.samba.hooks.samba.smbclient.open_file", return_value=mock.Mock())

--- a/providers/samba/tests/unit/samba/hooks/test_samba.py
+++ b/providers/samba/tests/unit/samba/hooks/test_samba.py
@@ -160,12 +160,26 @@ class TestSambaHook:
             ("/start/path/with/slash/windows", "windows", r"\\ip\share\start\path\with\slash\windows"),
             ("start/path/without/slash/windows", "windows", r"\\ip\share\start\path\without\slash\windows"),
             # Windows path -> Windows path, explicit path_type (windows)
-            (r"\start\path\with\backslash\windows", "windows", r"\\ip\share\start\path\with\backslash\windows"),
-            (r"start\path\without\backslash\windows", "windows", r"\\ip\share\start\path\without\backslash\windows"),
+            (
+                r"\start\path\with\backslash\windows",
+                "windows",
+                r"\\ip\share\start\path\with\backslash\windows",
+            ),
+            (
+                r"start\path\without\backslash\windows",
+                "windows",
+                r"\\ip\share\start\path\without\backslash\windows",
+            ),
         ],
     )
     @mock.patch(f"{BASEHOOK_PATCH_PATH}.get_connection")
-    def test__join_path(self, get_conn_mock, path, path_type, full_path,):
+    def test__join_path(
+        self,
+        get_conn_mock,
+        path,
+        path_type,
+        full_path,
+    ):
         CONNECTION = Connection(
             host="ip",
             schema="share",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add support for Windows-like path in SambaHook. By default, the hook formats for Posix. When share_type is set to "windows", the path is rewritten for Windows.


<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
